### PR TITLE
Can't run unit tests locally on MacOS

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -4,6 +4,7 @@ coverage==5.0.3
 ipykernel==4.8.2
 msmb-theme==1.2.0
 nbsphinx-link==1.2
+opencv-python-headless==4.1.2.30
 pytest==3.6.4
 pytest-cov==2.6.0
 pytest-flake8==1.0.2


### PR DESCRIPTION
## 🐛 **Bug**
It is not possible to run unit tests locally on MacOS X (10.12).
## **To Reproduce**
Steps to reproduce the behavior:

1. Create a conda environment and install all of the packages as suggested [here](https://github.com/imelekhov/solt/blob/master/CONTRIBUTING.md).

1. Run the following code:
`pytest tests`

1. The unit tests fail and generate an error:
```
ImportError while importing test module '/Users/melekhi1/projects/solt/tests/test_data_core.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
tests/test_data_core.py:4: in <module>
    import cv2
../../anaconda2/envs/solt_test_env/lib/python3.8/site-packages/cv2/__init__.py:3: in <module>
    from .cv2 import *
E   ImportError: dlopen(/Users/melekhi1/anaconda2/envs/solt_test_env/lib/python3.8/site-packages/cv2/cv2.cpython-38-darwin.so, 2): Symbol not found: _inflateValidate
E     Referenced from: /Users/melekhi1/anaconda2/envs/solt_test_env/lib/python3.8/site-packages/cv2/.dylibs/libpng16.16.dylib (which was built for Mac OS X 10.13)
E     Expected in: /usr/lib/libz.1.dylib
E    in /Users/melekhi1/anaconda2/envs/solt_test_env/lib/python3.8/site-packages/cv2/.dylibs/libpng16.16.dylib
```
## **Expected behavior**
The unit tests should pass
```
=============================== test session starts ================================
platform darwin -- Python 3.8.2, pytest-3.6.4, py-1.8.1, pluggy-0.7.1
rootdir: /Users/melekhi1/projects/solt, inifile:
plugins: pep8-1.0.6, flake8-1.0.2, cov-2.6.0
collected 701 items

tests/test_base_transforms.py .............................................. [  6%]
............................................................................ [ 17%]
.....                                                                        [ 18%]
tests/test_data_core.py .................................................... [ 25%]
............................................................................ [ 36%]
............................................................................ [ 47%]
..................................................................           [ 56%]
tests/test_transforms.py ................................................... [ 63%]
............................................................................ [ 74%]
............................................................................ [ 85%]
............................................................................ [ 96%]
.........                                                                    [ 97%]
tests/test_utils.py ................                                         [100%]

============================ 701 passed in 6.79 seconds ============================
```
## **Suggestions**
It seems the bug is related to the latest version of `opencv-python-headless` (4.2.0.32) package. Apparently, its previous version, **4.1.2.30**, could solve the issue at least for this particular platform (MacOS 10.12). It would be great to test this solution on more recent MacOS.

